### PR TITLE
Allow inline scripts in CSP for SvelteKit bootstrap

### DIFF
--- a/backend/internal/middleware/security.go
+++ b/backend/internal/middleware/security.go
@@ -23,13 +23,13 @@ func SecurityHeaders(next http.Handler) http.Handler {
 
 		// Content Security Policy - permissive for Monaco editor and SPA frontend
 		// - 'unsafe-eval': Required by Monaco editor for syntax highlighting
-		// - 'unsafe-inline': Required for Tailwind CSS and Monaco inline styles
+		// - 'unsafe-inline': Required for SvelteKit bootstrapping and Tailwind/Monaco inline styles
 		// - blob: Required for Monaco web workers
 		// - data: Required for fonts and embedded images
 		// - ws:/wss: Required for WebSocket connections
 		csp := strings.Join([]string{
 			"default-src 'self'",
-			"script-src 'self' 'unsafe-eval' blob:",
+			"script-src 'self' 'unsafe-eval' 'unsafe-inline' blob:",
 			"style-src 'self' 'unsafe-inline'",
 			"font-src 'self' data:",
 			"img-src 'self' data: blob:",


### PR DESCRIPTION
### Motivation
- Fix a white-screen issue in production where SvelteKit's client bootstrap was blocked by the Content Security Policy, preventing the frontend from initializing.

### Description
- Relax `Content-Security-Policy` in `backend/internal/middleware/security.go` by adding `'unsafe-inline'` to the `script-src` directive so SvelteKit bootstrapping and inline styles/scripts (e.g., Tailwind/Monaco) can run, and update the comment to reflect this requirement.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698892eb96ac8333bd31123832e978e7)