### PR TITLE
fix file creation and editing

### DIFF
--- a/backend/internal/handler/file.go
+++ b/backend/internal/handler/file.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -28,8 +29,9 @@ func (h *FileHandler) RegisterRoutes(r chi.Router) {
 	r.Get("/", h.ListRoots)
 	r.Get("/stats", h.GetDriveStats)
 	r.Get("/*", h.GetPath)
-	r.Post("/*", h.CreateDir)
+	r.Post("/*", h.CreateItem)
 	r.Put("/*", h.Rename)
+	r.Patch("/*", h.SaveFileContent)
 	r.Delete("/*", h.Delete)
 }
 
@@ -44,9 +46,11 @@ type RootsResponse struct {
 	Roots []MountPointResponse `json:"roots"`
 }
 
-// CreateDirRequest represents the create directory request body
-type CreateDirRequest struct {
-	Name string `json:"name"`
+// CreateItemRequest represents the create file/directory request body
+type CreateItemRequest struct {
+	Name    string `json:"name"`
+	Type    string `json:"type,omitempty"`
+	Content string `json:"content,omitempty"`
 }
 
 // RenameRequest represents the rename request body
@@ -54,6 +58,10 @@ type RenameRequest struct {
 	NewPath string `json:"newPath"`
 }
 
+// SaveFileRequest represents the file content save request body
+type SaveFileRequest struct {
+	Content string `json:"content"`
+}
 
 // ListRoots returns all configured mount points
 // GET /api/v1/files
@@ -116,26 +124,31 @@ func (h *FileHandler) GetPath(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// CreateDir creates a new directory
+// CreateItem creates a new directory or file
 // POST /api/v1/files/*path
-func (h *FileHandler) CreateDir(w http.ResponseWriter, r *http.Request) {
+func (h *FileHandler) CreateItem(w http.ResponseWriter, r *http.Request) {
 	basePath := chi.URLParam(r, "*")
 
-	var req CreateDirRequest
+	var req CreateItemRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, "Invalid request body", model.ErrCodeValidationError, http.StatusBadRequest)
 		return
 	}
 
-	// Validate directory name
+	itemType := req.Type
+	if itemType == "" {
+		itemType = "directory"
+	}
+
+	// Validate item name
 	if req.Name == "" {
-		writeError(w, "Directory name is required", model.ErrCodeValidationError, http.StatusBadRequest)
+		writeError(w, "Name is required", model.ErrCodeValidationError, http.StatusBadRequest)
 		return
 	}
 
 	// Check for invalid characters in name
-	if strings.ContainsAny(req.Name, "/\\") {
-		writeError(w, "Directory name cannot contain path separators", model.ErrCodeValidationError, http.StatusBadRequest)
+	if strings.ContainsAny(req.Name, "/\\") || req.Name == "." || req.Name == ".." || strings.ContainsRune(req.Name, 0) {
+		writeError(w, "Name cannot contain path separators or special path names", model.ErrCodeValidationError, http.StatusBadRequest)
 		return
 	}
 
@@ -147,13 +160,41 @@ func (h *FileHandler) CreateDir(w http.ResponseWriter, r *http.Request) {
 		fullPath = req.Name
 	}
 
-	// Create directory
-	if err := h.fileService.CreateDir(r.Context(), fullPath); err != nil {
-		HandleServiceError(w, err)
+	switch itemType {
+	case "directory", "folder":
+		// Create directory
+		if err := h.fileService.CreateDir(r.Context(), fullPath); err != nil {
+			HandleServiceError(w, err)
+			return
+		}
+	case "file":
+		// Create file without overwriting any existing item
+		file, err := h.fileService.CreateFile(r.Context(), fullPath)
+		if err != nil {
+			HandleServiceError(w, err)
+			return
+		}
+
+		if req.Content != "" {
+			if _, err := io.WriteString(file, req.Content); err != nil {
+				_ = file.Close()
+				_ = h.fileService.Delete(r.Context(), fullPath)
+				writeError(w, "Failed to write file content", model.ErrCodeInternalError, http.StatusInternalServerError)
+				return
+			}
+		}
+
+		if err := file.Close(); err != nil {
+			_ = h.fileService.Delete(r.Context(), fullPath)
+			writeError(w, "Failed to create file", model.ErrCodeInternalError, http.StatusInternalServerError)
+			return
+		}
+	default:
+		writeError(w, "Type must be file or directory", model.ErrCodeValidationError, http.StatusBadRequest)
 		return
 	}
 
-	// Return the created directory info
+	// Return the created item info
 	info, err := h.fileService.GetInfo(r.Context(), fullPath)
 	if err != nil {
 		HandleServiceError(w, err)
@@ -163,6 +204,34 @@ func (h *FileHandler) CreateDir(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, info, http.StatusCreated)
 }
 
+// SaveFileContent overwrites an existing file's content
+// PATCH /api/v1/files/*path
+func (h *FileHandler) SaveFileContent(w http.ResponseWriter, r *http.Request) {
+	path := chi.URLParam(r, "*")
+	if path == "" {
+		writeError(w, "Path is required", model.ErrCodeValidationError, http.StatusBadRequest)
+		return
+	}
+
+	var req SaveFileRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "Invalid request body", model.ErrCodeValidationError, http.StatusBadRequest)
+		return
+	}
+
+	if err := h.fileService.WriteFile(r.Context(), path, []byte(req.Content)); err != nil {
+		HandleServiceError(w, err)
+		return
+	}
+
+	info, err := h.fileService.GetInfo(r.Context(), path)
+	if err != nil {
+		HandleServiceError(w, err)
+		return
+	}
+
+	writeJSON(w, info, http.StatusOK)
+}
 
 // Rename renames/moves a file or directory
 // PUT /api/v1/files/*path
@@ -236,7 +305,6 @@ func (h *FileHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]string{"message": "Deleted successfully"}, http.StatusOK)
 }
 
-
 // parseListOptions extracts listing options from query parameters
 func (h *FileHandler) parseListOptions(r *http.Request) model.ListOptions {
 	opts := model.DefaultListOptions()
@@ -274,5 +342,3 @@ func (h *FileHandler) parseListOptions(r *http.Request) model.ListOptions {
 
 	return opts
 }
-
-

--- a/backend/internal/handler/file_test.go
+++ b/backend/internal/handler/file_test.go
@@ -1,0 +1,113 @@
+package handler
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/homelab/filemanager/internal/model"
+	"github.com/homelab/filemanager/internal/pkg/filesystem"
+	"github.com/homelab/filemanager/internal/service"
+)
+
+func setupTestFileHandler() (*FileHandler, *filesystem.AferoFS) {
+	fs := filesystem.NewMemMapFS()
+	_ = fs.MkdirAll("/data/media", 0755)
+	_ = fs.MkdirAll("/data/documents", 0755)
+
+	mounts := []model.MountPoint{
+		{Name: "media", Path: "/data/media", ReadOnly: false},
+		{Name: "documents", Path: "/data/documents", ReadOnly: false},
+	}
+
+	fileSvc := service.NewFileService(fs, service.FileServiceConfig{MountPoints: mounts})
+	return NewFileHandler(fileSvc), fs
+}
+
+func createFileTestRouter(handler *FileHandler) *chi.Mux {
+	r := chi.NewRouter()
+	r.Route("/api/v1/files", func(r chi.Router) {
+		handler.RegisterRoutes(r)
+	})
+	return r
+}
+
+func TestCreateItemCreatesFileViaAPI(t *testing.T) {
+	handler, fs := setupTestFileHandler()
+	router := createFileTestRouter(handler)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/files/media",
+		bytes.NewBufferString(`{"name":"note.txt","type":"file"}`),
+	)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	content, err := fs.ReadFile("/data/media/note.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "" {
+		t.Fatalf("expected empty file, got %q", string(content))
+	}
+}
+
+func TestCreateItemRejectsExistingFileViaAPI(t *testing.T) {
+	handler, fs := setupTestFileHandler()
+	router := createFileTestRouter(handler)
+
+	if err := fs.WriteFile("/data/media/note.txt", []byte("existing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/files/media",
+		bytes.NewBufferString(`{"name":"note.txt","type":"file"}`),
+	)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusConflict, rec.Code, rec.Body.String())
+	}
+}
+
+func TestSaveFileContentViaAPI(t *testing.T) {
+	handler, fs := setupTestFileHandler()
+	router := createFileTestRouter(handler)
+
+	if err := fs.WriteFile("/data/media/editable.txt", []byte("before"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		"/api/v1/files/media/editable.txt",
+		bytes.NewBufferString(`{"content":"after"}`),
+	)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	content, err := fs.ReadFile("/data/media/editable.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "after" {
+		t.Fatalf("expected overwritten content, got %q", string(content))
+	}
+}

--- a/backend/internal/service/file.go
+++ b/backend/internal/service/file.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -62,6 +63,8 @@ type FileService interface {
 	OpenFile(ctx context.Context, path string) (File, *model.FileInfo, error)
 	// CreateFile creates a new file for writing using the filesystem abstraction
 	CreateFile(ctx context.Context, path string) (WriteFile, error)
+	// WriteFile overwrites an existing file using the filesystem abstraction
+	WriteFile(ctx context.Context, path string, content []byte) error
 	// GetFilesystem returns the underlying filesystem for advanced operations
 	GetFilesystem() filesystem.FS
 }
@@ -409,6 +412,15 @@ func (s *fileService) CreateFile(ctx context.Context, path string) (WriteFile, e
 		return nil, ErrPermissionDenied
 	}
 
+	// New-file creation must not truncate an existing item.
+	exists, err := s.fs.Exists(fsPath)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, ErrPathExists
+	}
+
 	// Ensure parent directory exists
 	parentDir := filepath.Dir(fsPath)
 	if err := s.fs.MkdirAll(parentDir, 0755); err != nil {
@@ -416,12 +428,42 @@ func (s *fileService) CreateFile(ctx context.Context, path string) (WriteFile, e
 	}
 
 	// Create the file
-	file, err := s.fs.Create(fsPath)
+	file, err := s.fs.OpenFile(fsPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
 	if err != nil {
 		return nil, err
 	}
 
 	return file, nil
+}
+
+// WriteFile overwrites an existing file using the filesystem abstraction
+func (s *fileService) WriteFile(ctx context.Context, path string, content []byte) error {
+	// Resolve the path to filesystem path
+	mount, fsPath, err := s.ResolvePath(path)
+	if err != nil {
+		if errors.Is(err, validator.ErrOutsideMountPoint) {
+			return ErrMountPointNotFound
+		}
+		return err
+	}
+
+	// Check if mount is read-only
+	if mount.ReadOnly {
+		return ErrPermissionDenied
+	}
+
+	info, err := s.fs.Stat(fsPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return ErrPathNotFound
+		}
+		return err
+	}
+	if info.IsDir() {
+		return ErrNotFile
+	}
+
+	return s.fs.WriteFile(fsPath, content, info.Mode().Perm())
 }
 
 // GetFilesystem returns the underlying filesystem for advanced operations

--- a/backend/internal/service/file_property_test.go
+++ b/backend/internal/service/file_property_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -69,6 +70,60 @@ func TestDirectoryListingPutsVisibleItemsBeforeHiddenItems(t *testing.T) {
 	want := []string{"Desktop", "Documents", "Downloads"}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("expected first page to contain visible items %v, got %v", want, got)
+	}
+}
+
+func TestCreateFileCreatesEmptyFileWithoutOverwriting(t *testing.T) {
+	svc, fs := setupTestFileService()
+	ctx := context.Background()
+
+	file, err := svc.CreateFile(ctx, "media/new-note.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := fs.ReadFile("/data/media/new-note.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "" {
+		t.Fatalf("expected created file to be empty, got %q", string(content))
+	}
+
+	existing, err := svc.CreateFile(ctx, "media/new-note.txt")
+	if existing != nil {
+		_ = existing.Close()
+	}
+	if !errors.Is(err, ErrPathExists) {
+		t.Fatalf("expected ErrPathExists, got %v", err)
+	}
+}
+
+func TestWriteFileOverwritesExistingFileOnly(t *testing.T) {
+	svc, fs := setupTestFileService()
+	ctx := context.Background()
+
+	if err := fs.WriteFile("/data/media/editable.txt", []byte("before"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.WriteFile(ctx, "media/editable.txt", []byte("after")); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := fs.ReadFile("/data/media/editable.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "after" {
+		t.Fatalf("expected overwritten content, got %q", string(content))
+	}
+
+	if err := svc.WriteFile(ctx, "media/missing.txt", []byte("new")); !errors.Is(err, ErrPathNotFound) {
+		t.Fatalf("expected ErrPathNotFound, got %v", err)
 	}
 }
 

--- a/docs/awesome-selfhosted-boxbox.yml
+++ b/docs/awesome-selfhosted-boxbox.yml
@@ -1,0 +1,11 @@
+name: BoxBox
+website_url: https://boxbox.radhey.dev
+source_code_url: https://github.com/jR4dh3y/BoxBox
+description: Browser file manager for homelab and NAS-style servers with mounted path browsing, large uploads, previews, search, and background file operations.
+licenses:
+  - MIT
+platforms:
+  - Go
+  - Docker
+tags:
+  - File Transfer - Web-based File Managers

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -132,7 +132,7 @@ async function refreshAccessToken(): Promise<boolean> {
  * Request options for the API client
  */
 export interface RequestOptions {
-	method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+	method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 	body?: unknown;
 	headers?: Record<string, string>;
 	skipAuth?: boolean;
@@ -254,6 +254,9 @@ export const api = {
 	post: <T>(endpoint: string, body?: unknown) => apiRequest<T>(endpoint, { method: 'POST', body }),
 
 	put: <T>(endpoint: string, body?: unknown) => apiRequest<T>(endpoint, { method: 'PUT', body }),
+
+	patch: <T>(endpoint: string, body?: unknown) =>
+		apiRequest<T>(endpoint, { method: 'PATCH', body }),
 
 	delete: <T>(endpoint: string, params?: Record<string, string | number | boolean | undefined>) =>
 		apiRequest<T>(endpoint, { method: 'DELETE', params })

--- a/frontend/src/lib/api/files.ts
+++ b/frontend/src/lib/api/files.ts
@@ -91,10 +91,12 @@ export interface SearchResponse {
 }
 
 /**
- * Create directory request
+ * Create file/directory request
  */
-interface CreateDirRequest {
+interface CreateItemRequest {
 	name: string;
+	type?: 'file' | 'directory';
+	content?: string;
 }
 
 /**
@@ -102,6 +104,13 @@ interface CreateDirRequest {
  */
 interface RenameRequest {
 	newPath: string;
+}
+
+/**
+ * Save file content request
+ */
+interface SaveFileRequest {
+	content: string;
 }
 
 /**
@@ -166,7 +175,20 @@ export async function getFileInfo(path: string): Promise<FileInfo> {
  * POST /api/v1/files/*path
  */
 export async function createDirectory(basePath: string, name: string): Promise<FileInfo> {
-	const body: CreateDirRequest = { name };
+	const body: CreateItemRequest = { name, type: 'directory' };
+	return api.post<FileInfo>(`/files/${basePath}`, body);
+}
+
+/**
+ * Create a new empty file
+ * POST /api/v1/files/*path
+ */
+export async function createFile(
+	basePath: string,
+	name: string,
+	content: string = ''
+): Promise<FileInfo> {
+	const body: CreateItemRequest = { name, type: 'file', content };
 	return api.post<FileInfo>(`/files/${basePath}`, body);
 }
 
@@ -177,6 +199,15 @@ export async function createDirectory(basePath: string, name: string): Promise<F
 export async function rename(oldPath: string, newPath: string): Promise<FileInfo> {
 	const body: RenameRequest = { newPath };
 	return api.put<FileInfo>(`/files/${oldPath}`, body);
+}
+
+/**
+ * Save file content
+ * PATCH /api/v1/files/*path
+ */
+export async function saveFileContent(path: string, content: string): Promise<FileInfo> {
+	const body: SaveFileRequest = { content };
+	return api.patch<FileInfo>(`/files/${path}`, body);
 }
 
 /**
@@ -207,7 +238,9 @@ export const filesApi = {
 	listDirectory,
 	getFileInfo,
 	createDirectory,
+	createFile,
 	rename,
+	saveFileContent,
 	delete: deleteFile,
 	search
 };

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -28,7 +28,9 @@ export {
 	listDirectory,
 	getFileInfo,
 	createDirectory,
+	createFile,
 	rename,
+	saveFileContent,
 	deleteFile,
 	search,
 	type FileInfo,
@@ -59,8 +61,4 @@ export {
 } from './jobs';
 
 // System API
-export {
-	getSystemDrives,
-	type SystemDrive,
-	type SystemDrivesResponse
-} from './system';
+export { getSystemDrives, type SystemDrive, type SystemDrivesResponse } from './system';

--- a/frontend/src/lib/components/FileGrid.svelte
+++ b/frontend/src/lib/components/FileGrid.svelte
@@ -21,6 +21,7 @@
 		cutPaths = new SvelteSet<string>(),
 		favoritePaths = new SvelteSet<string>(),
 		canPaste = false,
+		canCreate = false,
 		onItemClick,
 		onSelectionChange,
 		onContextMenuAction
@@ -33,6 +34,7 @@
 		cutPaths?: Set<string>;
 		favoritePaths?: Set<string>;
 		canPaste?: boolean;
+		canCreate?: boolean;
 		onItemClick?: (item: FileInfo) => void;
 		onSelectionChange?: (paths: Set<string>) => void;
 		onContextMenuAction?: (action: string, items: FileInfo[]) => void;
@@ -88,6 +90,19 @@
 		};
 	}
 
+	function handleBackgroundContextMenu(event: MouseEvent) {
+		const target = event.target instanceof HTMLElement ? event.target : null;
+		if (target?.closest('[data-file-item="true"]')) return;
+
+		event.preventDefault();
+		onSelectionChange?.(new SvelteSet<string>());
+		contextMenu = {
+			x: event.clientX,
+			y: event.clientY,
+			items: []
+		};
+	}
+
 	function handleContextMenuClose() {
 		contextMenu = null;
 	}
@@ -120,7 +135,11 @@
 		'flex shrink-0 items-center justify-center overflow-hidden rounded border border-border-primary bg-surface-primary';
 </script>
 
-<div class="relative h-full w-full overflow-auto bg-surface-primary">
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="relative h-full w-full overflow-auto bg-surface-primary"
+	oncontextmenu={handleBackgroundContextMenu}
+>
 	{#if isLoading}
 		<div class="absolute inset-0 z-10 flex items-center justify-center bg-surface-primary/80">
 			<Spinner />
@@ -159,6 +178,7 @@
 					ondblclick={() => handleOpen(item)}
 					onkeydown={(e) => handleKeyDown(item, e)}
 					oncontextmenu={(e) => handleContextMenu(item, e)}
+					data-file-item="true"
 				>
 					<div class="{thumbnailClass} {compactMode ? 'h-11' : 'h-16'}">
 						{#if showThumbnail}
@@ -199,7 +219,12 @@
 
 {#if contextMenu}
 	<ContextMenu
-		items={getFileContextMenuItems({ items: contextMenu.items, canPaste, favoritePaths })}
+		items={getFileContextMenuItems({
+			items: contextMenu.items,
+			canPaste,
+			favoritePaths,
+			canCreate
+		})}
 		x={contextMenu.x}
 		y={contextMenu.y}
 		onSelect={handleContextMenuSelect}

--- a/frontend/src/lib/components/FileList.svelte
+++ b/frontend/src/lib/components/FileList.svelte
@@ -10,7 +10,7 @@
 	import { getFileTypeDescription, getFileIcon } from '$lib/utils/fileTypes';
 	import { getFileContextMenuItems } from '$lib/utils/fileContextMenu';
 	import { SvelteSet } from 'svelte/reactivity';
-	import { Spinner, ContextMenu, type ContextMenuItem } from '$lib/components/ui';
+	import { Spinner, ContextMenu } from '$lib/components/ui';
 	import { FolderOpen } from 'lucide-svelte';
 
 	let {
@@ -24,6 +24,7 @@
 		cutPaths = new SvelteSet<string>(),
 		favoritePaths = new SvelteSet<string>(),
 		canPaste = false,
+		canCreate = false,
 		onItemClick,
 		onSortChange,
 		onSelectionChange,
@@ -39,6 +40,7 @@
 		cutPaths?: Set<string>;
 		favoritePaths?: Set<string>;
 		canPaste?: boolean;
+		canCreate?: boolean;
 		onItemClick?: (item: FileInfo) => void;
 		onSortChange?: (field: SortField, dir: SortDir) => void;
 		onSelectionChange?: (paths: Set<string>) => void;
@@ -106,6 +108,19 @@
 		};
 	}
 
+	function handleBackgroundContextMenu(event: MouseEvent) {
+		const target = event.target instanceof HTMLElement ? event.target : null;
+		if (target?.closest('[data-file-row="true"], [data-file-header="true"]')) return;
+
+		event.preventDefault();
+		onSelectionChange?.(new SvelteSet<string>());
+		contextMenu = {
+			x: event.clientX,
+			y: event.clientY,
+			items: []
+		};
+	}
+
 	function handleContextMenuClose() {
 		contextMenu = null;
 	}
@@ -137,7 +152,11 @@
 	const clippedCellClass = 'block overflow-hidden text-ellipsis whitespace-nowrap';
 </script>
 
-<div class="relative h-full w-full overflow-auto bg-surface-primary {compactMode ? 'compact' : ''}">
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="relative h-full w-full overflow-auto bg-surface-primary {compactMode ? 'compact' : ''}"
+	oncontextmenu={handleBackgroundContextMenu}
+>
 	{#if isLoading}
 		<div class="absolute inset-0 z-10 flex items-center justify-center bg-surface-primary/80">
 			<Spinner />
@@ -163,6 +182,7 @@
 					onkeydown={(e) => e.key === 'Enter' && handleSort('name')}
 					tabindex="0"
 					role="columnheader"
+					data-file-header="true"
 					aria-sort={sortBy === 'name' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
 				>
 					<span class="mr-1">Name</span>
@@ -174,6 +194,7 @@
 					onkeydown={(e) => e.key === 'Enter' && handleSort('type')}
 					tabindex="0"
 					role="columnheader"
+					data-file-header="true"
 					aria-sort={sortBy === 'type' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
 				>
 					<span class="mr-1">Type</span>
@@ -185,6 +206,7 @@
 					onkeydown={(e) => e.key === 'Enter' && handleSort('size')}
 					tabindex="0"
 					role="columnheader"
+					data-file-header="true"
 					aria-sort={sortBy === 'size' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
 				>
 					<span class="mr-1">Size</span>
@@ -196,6 +218,7 @@
 					onkeydown={(e) => e.key === 'Enter' && handleSort('modTime')}
 					tabindex="0"
 					role="columnheader"
+					data-file-header="true"
 					aria-sort={sortBy === 'modTime'
 						? sortDir === 'asc'
 							? 'ascending'
@@ -235,6 +258,7 @@
 						oncontextmenu={(e) => handleContextMenu(item, e)}
 						tabindex="0"
 						aria-selected={isSelected(item.path)}
+						data-file-row="true"
 					>
 						<td class={tdClass}>
 							<div class="flex min-w-0 items-center gap-2">
@@ -273,7 +297,12 @@
 <!-- Context Menu -->
 {#if contextMenu}
 	<ContextMenu
-		items={getFileContextMenuItems({ items: contextMenu.items, canPaste, favoritePaths })}
+		items={getFileContextMenuItems({
+			items: contextMenu.items,
+			canPaste,
+			favoritePaths,
+			canCreate
+		})}
 		x={contextMenu.x}
 		y={contextMenu.y}
 		onSelect={handleContextMenuSelect}

--- a/frontend/src/lib/components/FilePreview.svelte
+++ b/frontend/src/lib/components/FilePreview.svelte
@@ -20,10 +20,11 @@
 		file: FileInfo | null;
 		allFiles?: FileInfo[];
 		onNavigate?: (file: FileInfo) => void;
+		onFileSaved?: (file: FileInfo) => void;
 		onClose: () => void;
 	}
 
-	let { file, allFiles = [], onNavigate, onClose }: Props = $props();
+	let { file, allFiles = [], onNavigate, onFileSaved, onClose }: Props = $props();
 
 	let isFullscreen = $state(false);
 
@@ -190,7 +191,12 @@
 				{:else if previewType === 'notebook'}
 					<NotebookPreview url={previewUrl} filename={file.name} />
 				{:else if previewType === 'code' || previewType === 'text'}
-					<CodePreview url={previewUrl} filename={file.name} />
+					<CodePreview
+						url={previewUrl}
+						filename={file.name}
+						path={file.path}
+						onSaved={onFileSaved}
+					/>
 				{:else}
 					<div class="flex flex-col items-center gap-4 text-sm text-text-secondary">
 						<p>Preview not available for this file type</p>

--- a/frontend/src/lib/components/preview/CodePreview.svelte
+++ b/frontend/src/lib/components/preview/CodePreview.svelte
@@ -4,35 +4,109 @@
 	 */
 	import { onMount, onDestroy } from 'svelte';
 	import { getMonacoLanguage } from '$lib/utils/fileTypes';
-	import { getFileContent } from '$lib/api/files';
-	import { Spinner } from '$lib/components/ui';
+	import { getFileContent, saveFileContent, type FileInfo } from '$lib/api/files';
+	import { Button, Spinner } from '$lib/components/ui';
 
 	interface Props {
 		url: string;
 		filename: string;
+		path: string;
+		onSaved?: (file: FileInfo) => void;
 	}
 
-	let { url, filename }: Props = $props();
+	let { url, filename, path, onSaved }: Props = $props();
 
 	let containerElement: HTMLDivElement | null = $state(null);
 	let editor: any = $state(null);
 	let monaco: any = $state(null);
+	let changeDisposable: { dispose: () => void } | null = null;
 	let content = $state<string | null>(null);
 	let error = $state<string | null>(null);
 	let loading = $state(true);
+	let saving = $state(false);
+	let dirty = $state(false);
+	let saveError = $state<string | null>(null);
+	let saveMessage = $state<string | null>(null);
 
 	const language = $derived(getMonacoLanguage(filename));
+	const canSave = $derived(Boolean(editor) && dirty && !loading && !saving && !error);
+
+	function getErrorMessage(value: unknown): string {
+		return value instanceof Error ? value.message : 'Failed to save file.';
+	}
+
+	function defineTheme() {
+		monaco.editor.defineTheme('filemanager-dark', {
+			base: 'vs-dark',
+			inherit: true,
+			rules: [],
+			colors: {
+				'editor.background': '#1e1e1e',
+				'editor.foreground': '#d4d4d4',
+				'editorLineNumber.foreground': '#5a5a5a',
+				'editorLineNumber.activeForeground': '#c6c6c6',
+				'editor.selectionBackground': '#264f78',
+				'editor.lineHighlightBackground': '#2a2a2a'
+			}
+		});
+	}
+
+	function createEditor() {
+		if (!monaco || !containerElement || editor) return;
+
+		defineTheme();
+		editor = monaco.editor.create(containerElement, {
+			value: content ?? '',
+			language: language,
+			theme: 'filemanager-dark',
+			readOnly: false,
+			minimap: { enabled: true },
+			scrollBeyondLastLine: false,
+			fontSize: 13,
+			fontFamily: "'Fira Code', 'Cascadia Code', 'JetBrains Mono', Consolas, monospace",
+			lineNumbers: 'on',
+			renderLineHighlight: 'line',
+			automaticLayout: true,
+			wordWrap: 'on',
+			scrollbar: {
+				vertical: 'auto',
+				horizontal: 'auto',
+				verticalScrollbarSize: 10,
+				horizontalScrollbarSize: 10
+			}
+		});
+
+		changeDisposable = editor.onDidChangeModelContent(() => {
+			dirty = content !== null && editor.getValue() !== content;
+			saveMessage = null;
+		});
+		editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+			void handleSave();
+		});
+	}
+
+	async function handleSave() {
+		if (!editor || saving || !dirty) return;
+
+		saving = true;
+		saveError = null;
+		saveMessage = null;
+
+		const nextContent = editor.getValue();
+		try {
+			const savedFile = await saveFileContent(path, nextContent);
+			content = nextContent;
+			dirty = false;
+			saveMessage = 'Saved';
+			onSaved?.(savedFile);
+		} catch (saveResult) {
+			saveError = getErrorMessage(saveResult);
+		} finally {
+			saving = false;
+		}
+	}
 
 	onMount(async () => {
-		// Load file content
-		try {
-			content = await getFileContent(url);
-		} catch (e) {
-			error = 'Failed to load file content.';
-			loading = false;
-			return;
-		}
-
 		// Dynamically import Monaco Editor
 		try {
 			const monacoModule = await import('monaco-editor');
@@ -42,83 +116,110 @@
 			self.MonacoEnvironment = {
 				getWorker: function (_moduleId: string, label: string) {
 					return new Worker(
-						URL.createObjectURL(new Blob([`self.onmessage = function() {}`], { type: 'text/javascript' }))
+						URL.createObjectURL(
+							new Blob([`self.onmessage = function() {}`], { type: 'text/javascript' })
+						)
 					);
-				},
+				}
 			};
 
-			if (containerElement && content !== null) {
-				// Define dark theme
-				monaco.editor.defineTheme('filemanager-dark', {
-					base: 'vs-dark',
-					inherit: true,
-					rules: [],
-					colors: {
-						'editor.background': '#1e1e1e',
-						'editor.foreground': '#d4d4d4',
-						'editorLineNumber.foreground': '#5a5a5a',
-						'editorLineNumber.activeForeground': '#c6c6c6',
-						'editor.selectionBackground': '#264f78',
-						'editor.lineHighlightBackground': '#2a2a2a',
-					},
-				});
-
-				editor = monaco.editor.create(containerElement, {
-					value: content,
-					language: language,
-					theme: 'filemanager-dark',
-					readOnly: true,
-					minimap: { enabled: true },
-					scrollBeyondLastLine: false,
-					fontSize: 13,
-					fontFamily: "'Fira Code', 'Cascadia Code', 'JetBrains Mono', Consolas, monospace",
-					lineNumbers: 'on',
-					renderLineHighlight: 'line',
-					automaticLayout: true,
-					wordWrap: 'on',
-					scrollbar: {
-						vertical: 'auto',
-						horizontal: 'auto',
-						verticalScrollbarSize: 10,
-						horizontalScrollbarSize: 10,
-					},
-				});
-			}
+			createEditor();
 		} catch (e) {
 			console.error('Failed to load Monaco Editor:', e);
 			// Fallback to plain text display
 		}
-
-		loading = false;
 	});
 
 	onDestroy(() => {
+		if (changeDisposable) {
+			changeDisposable.dispose();
+		}
 		if (editor) {
 			editor.dispose();
 		}
 	});
 
-	// Update editor content when URL changes
+	// Load file content whenever preview navigation changes the URL.
 	$effect(() => {
-		if (editor && content !== null) {
-			editor.setValue(content);
-			if (monaco) {
-				monaco.editor.setModelLanguage(editor.getModel(), language);
-			}
+		const sourceUrl = url;
+		let cancelled = false;
+
+		loading = true;
+		error = null;
+		content = null;
+		dirty = false;
+		saveError = null;
+		saveMessage = null;
+
+		getFileContent(sourceUrl)
+			.then((fileContent) => {
+				if (cancelled) return;
+				content = fileContent;
+			})
+			.catch(() => {
+				if (cancelled) return;
+				error = 'Failed to load file content.';
+			})
+			.finally(() => {
+				if (!cancelled) {
+					loading = false;
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	$effect(() => {
+		createEditor();
+	});
+
+	// Keep Monaco in sync with loaded content and previewed filename.
+	$effect(() => {
+		if (!editor || content === null) return;
+
+		editor.setValue(content);
+		dirty = false;
+		if (monaco) {
+			monaco.editor.setModelLanguage(editor.getModel(), language);
 		}
 	});
 </script>
 
-<div class="w-full h-full flex flex-col bg-surface-primary">
+<div class="flex h-full w-full flex-col bg-surface-primary">
 	{#if loading}
-		<div class="flex items-center justify-center h-full">
+		<div class="flex h-full items-center justify-center">
 			<Spinner />
 		</div>
 	{:else if error}
-		<div class="flex items-center justify-center h-full text-danger text-sm p-5">{error}</div>
+		<div class="flex h-full items-center justify-center p-5 text-sm text-danger">{error}</div>
 	{:else if !editor && content !== null}
 		<!-- Fallback: plain text display if Monaco fails to load -->
-		<pre class="flex-1 m-0 p-4 overflow-auto bg-surface-primary text-text-primary font-mono text-[13px] leading-relaxed whitespace-pre-wrap break-words">{content}</pre>
+		<pre
+			class="m-0 flex-1 overflow-auto bg-surface-primary p-4 font-mono text-[13px] leading-relaxed break-words whitespace-pre-wrap text-text-primary">{content}</pre>
+	{:else}
+		<div
+			class="flex shrink-0 items-center justify-between gap-3 border-b border-border-primary bg-surface-secondary px-3 py-2"
+		>
+			<div class="min-w-0 text-xs text-text-secondary">
+				<span class="font-medium text-text-primary">Editable</span>
+				<span class="ml-2">{dirty ? 'Unsaved changes' : saveMessage || 'No changes'}</span>
+			</div>
+			<div class="flex items-center gap-3">
+				{#if saveError}
+					<span class="max-w-80 truncate text-xs text-danger" title={saveError}>{saveError}</span>
+				{/if}
+				<Button size="sm" variant="secondary" onclick={handleSave} disabled={!canSave}>
+					{saving ? 'Saving...' : 'Save'}
+				</Button>
+			</div>
+		</div>
 	{/if}
-	<div bind:this={containerElement} class="flex-1 w-full min-h-0 {loading || error || (!editor && content !== null) ? 'hidden' : ''}"></div>
+	<div
+		bind:this={containerElement}
+		class="min-h-0 w-full flex-1 {loading || error || (!editor && content !== null)
+			? 'hidden'
+			: ''}"
+	></div>
 </div>

--- a/frontend/src/lib/utils/fileContextMenu.ts
+++ b/frontend/src/lib/utils/fileContextMenu.ts
@@ -9,6 +9,8 @@ import {
 	Copy,
 	Scissors,
 	ClipboardPaste,
+	FilePlus,
+	FolderPlus,
 	Pencil,
 	Trash2,
 	Download,
@@ -18,6 +20,8 @@ import {
 } from 'lucide-svelte';
 
 export type FileContextAction =
+	| 'new-file'
+	| 'new-folder'
 	| 'copy'
 	| 'cut'
 	| 'paste'
@@ -35,6 +39,10 @@ export interface FileContextMenuOptions {
 	canPaste: boolean;
 	/** Paths currently pinned in the sidebar favorites section */
 	favoritePaths?: Set<string>;
+	/** Whether new files/folders can be created in the current location */
+	canCreate?: boolean;
+	/** Whether creation actions should be included in this menu */
+	includeCreateActions?: boolean;
 }
 
 /**
@@ -42,13 +50,35 @@ export interface FileContextMenuOptions {
  * Configures disabled states based on selection
  */
 export function getFileContextMenuItems(options: FileContextMenuOptions): ContextMenuItem[] {
-	const { items, canPaste, favoritePaths = new Set<string>() } = options;
+	const {
+		items,
+		canPaste,
+		favoritePaths = new Set<string>(),
+		canCreate = false,
+		includeCreateActions = true
+	} = options;
+	const hasSelection = items.length > 0;
 	const hasMultiple = items.length > 1;
 	const hasFolder = items.some((i) => i.isDir);
 	const singleFolder = !hasMultiple && items[0]?.isDir ? items[0] : null;
 	const isFavorite = singleFolder ? favoritePaths.has(singleFolder.path) : false;
+	const createItems: ContextMenuItem[] = includeCreateActions
+		? [
+				{ id: 'new-file', label: 'New File', icon: FilePlus, disabled: !canCreate },
+				{ id: 'new-folder', label: 'New Folder', icon: FolderPlus, disabled: !canCreate },
+				{ id: 'separator-create', label: '', separator: true }
+			]
+		: [];
+
+	if (!hasSelection) {
+		return [
+			...createItems,
+			{ id: 'paste', label: 'Paste', icon: ClipboardPaste, shortcut: 'Ctrl+V', disabled: !canPaste }
+		];
+	}
 
 	return [
+		...createItems,
 		{ id: 'copy', label: 'Copy', icon: Copy, shortcut: 'Ctrl+C' },
 		{ id: 'cut', label: 'Cut', icon: Scissors, shortcut: 'Ctrl+X' },
 		{ id: 'paste', label: 'Paste', icon: ClipboardPaste, shortcut: 'Ctrl+V', disabled: !canPaste },

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import { authStore, isAuthenticated } from '$lib/stores/auth';
 	import { onDestroy, onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
 	import { CONFIG } from '$lib/config';
@@ -27,7 +28,9 @@
 
 	// Public routes that don't require authentication
 	const publicRoutes = ['/login', '/test'];
-	const isBrowsePage = $derived(page.url.pathname.startsWith('/browse'));
+	const isWorkspacePage = $derived(
+		page.url.pathname.startsWith('/browse') || page.url.pathname.startsWith('/settings')
+	);
 	const isLoginPage = $derived(page.url.pathname.startsWith('/login'));
 
 	onMount(() => {
@@ -46,9 +49,9 @@
 		const isPublicRoute = publicRoutes.some((route) => currentPath.startsWith(route));
 
 		if (!$isAuthenticated && !isPublicRoute) {
-			goto('/login');
+			goto(resolve('/login'));
 		} else if ($isAuthenticated && currentPath.startsWith('/login')) {
-			goto('/browse');
+			goto(resolve('/browse'));
 		}
 	});
 
@@ -77,7 +80,7 @@
 
 	async function handleLogout() {
 		await authStore.logout();
-		goto('/login');
+		goto(resolve('/login'));
 	}
 </script>
 
@@ -88,7 +91,7 @@
 		<div class="flex min-h-screen items-center justify-center bg-surface-primary">
 			<Spinner size="lg" />
 		</div>
-	{:else if isBrowsePage}
+	{:else if isWorkspacePage}
 		{@render children()}
 	{:else}
 		<div class="flex min-h-screen flex-col bg-surface-primary">
@@ -96,7 +99,7 @@
 				<header class="sticky top-0 z-50 border-b border-border-secondary bg-surface-primary px-4">
 					<div class="mx-auto flex h-14 max-w-[1400px] items-center justify-between">
 						<a
-							href="/browse"
+							href={resolve('/browse')}
 							class="flex items-center gap-2 text-lg font-semibold text-text-primary no-underline hover:text-accent"
 						>
 							<FolderOpen size={24} class="text-accent" />

--- a/frontend/src/routes/browse/+page.svelte
+++ b/frontend/src/routes/browse/+page.svelte
@@ -4,6 +4,7 @@
 	 */
 	import { createQuery, useQueryClient } from '@tanstack/svelte-query';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import Toolbar from '$lib/components/Toolbar.svelte';
 	import FileList from '$lib/components/FileList.svelte';
@@ -30,6 +31,8 @@
 		listRoots,
 		listDirectory,
 		search,
+		createDirectory,
+		createFile,
 		rename,
 		deleteFile,
 		getDownloadUrl
@@ -69,6 +72,13 @@
 	let deleteDialog = $state<{ open: boolean; items: FileInfo[] }>({
 		open: false,
 		items: []
+	});
+
+	// Create file/folder dialog state
+	let createDialog = $state<{ open: boolean; type: 'file' | 'directory'; name: string }>({
+		open: false,
+		type: 'file',
+		name: ''
 	});
 
 	// Properties dialog state
@@ -158,6 +168,15 @@
 	const canGoBack = $derived(historyIndex > 0);
 	const canGoForward = $derived(historyIndex < historyStack.length - 1);
 	const canGoUp = $derived(segments.length > 0);
+	const currentMount = $derived(
+		path ? roots.find((root) => path === root.name || path.startsWith(`${root.name}/`)) : null
+	);
+	const isCurrentLocationReadOnly = $derived(currentMount?.readOnly ?? false);
+	const canCreate = $derived(!isAtRoot && !isCurrentLocationReadOnly);
+
+	function getErrorMessage(error: unknown, fallback: string): string {
+		return error instanceof Error ? error.message : fallback;
+	}
 
 	function handleNavigate(newPath: string) {
 		const newHistory = historyStack.slice(0, historyIndex + 1);
@@ -202,7 +221,7 @@
 	}
 
 	function handleSettings() {
-		goto('/settings');
+		goto(resolve('/settings'));
 	}
 
 	function handleFileClick(file: FileInfo) {
@@ -252,6 +271,14 @@
 	 */
 	async function handleContextMenuAction(action: string, items: FileInfo[]) {
 		switch (action) {
+			case 'new-file':
+				openCreateDialog('file');
+				break;
+
+			case 'new-folder':
+				openCreateDialog('directory');
+				break;
+
 			case 'copy':
 				clipboardStore.copy(items);
 				break;
@@ -310,6 +337,51 @@
 		}
 	}
 
+	function openCreateDialog(type: 'file' | 'directory') {
+		if (!canCreate) {
+			toastStore.error('Cannot create items in this location');
+			return;
+		}
+
+		createDialog = {
+			open: true,
+			type,
+			name: type === 'file' ? 'untitled.txt' : 'New Folder'
+		};
+	}
+
+	function closeCreateDialog() {
+		createDialog = { open: false, type: 'file', name: '' };
+	}
+
+	async function handleCreateConfirm() {
+		if (!path || !createDialog.name.trim()) return;
+
+		const name = createDialog.name.trim();
+		if (name.includes('/') || name.includes('\\')) {
+			toastStore.error('Name cannot contain path separators');
+			return;
+		}
+
+		try {
+			const created =
+				createDialog.type === 'file'
+					? await createFile(path, name)
+					: await createDirectory(path, name);
+
+			closeCreateDialog();
+			selectedPaths = new Set([created.path]);
+			toastStore.success(`${created.name} created`);
+			queryClient.invalidateQueries({ queryKey: fileQueryKeys.all });
+			directoryQuery.refetch();
+			if (isSearchActive) {
+				searchQueryResult.refetch();
+			}
+		} catch (error) {
+			toastStore.error(getErrorMessage(error, 'Create failed'));
+		}
+	}
+
 	/**
 	 * Handle paste operation
 	 */
@@ -338,6 +410,7 @@
 			directoryQuery.refetch();
 		} catch (error) {
 			console.error('Paste operation failed:', error);
+			toastStore.error(getErrorMessage(error, 'Paste failed'));
 		}
 	}
 
@@ -369,6 +442,7 @@
 			directoryQuery.refetch();
 		} catch (error) {
 			console.error('Rename failed:', error);
+			toastStore.error(getErrorMessage(error, 'Rename failed'));
 		}
 	}
 
@@ -392,6 +466,16 @@
 			directoryQuery.refetch();
 		} catch (error) {
 			console.error('Delete failed:', error);
+			toastStore.error(getErrorMessage(error, 'Delete failed'));
+		}
+	}
+
+	function handleFileSaved(file: FileInfo) {
+		previewFile = file;
+		queryClient.invalidateQueries({ queryKey: fileQueryKeys.all });
+		directoryQuery.refetch();
+		if (isSearchActive) {
+			searchQueryResult.refetch();
 		}
 	}
 
@@ -466,8 +550,7 @@
 		}
 
 		// Check if current mount is read-only
-		const currentMount = roots.find((r) => path.startsWith(r.name));
-		if (currentMount?.readOnly) {
+		if (isCurrentLocationReadOnly) {
 			toastStore.error('Cannot upload to read-only location');
 			return;
 		}
@@ -488,8 +571,7 @@
 		}
 
 		// Check if current mount is read-only
-		const currentMount = roots.find((r) => path.startsWith(r.name));
-		if (currentMount?.readOnly) {
+		if (isCurrentLocationReadOnly) {
 			toastStore.error('Cannot upload to read-only location');
 			return;
 		}
@@ -500,8 +582,7 @@
 	// Derived: is upload disabled (at root or read-only)
 	const uploadDisabled = $derived.by(() => {
 		if (isAtRoot) return true;
-		const currentMount = roots.find((r) => path.startsWith(r.name));
-		return currentMount?.readOnly ?? false;
+		return isCurrentLocationReadOnly;
 	});
 </script>
 
@@ -592,6 +673,7 @@
 					{cutPaths}
 					{favoritePaths}
 					{canPaste}
+					{canCreate}
 					onItemClick={handleFileClick}
 					onSelectionChange={handleSelectionChange}
 					onContextMenuAction={handleContextMenuAction}
@@ -608,6 +690,7 @@
 					{cutPaths}
 					{favoritePaths}
 					{canPaste}
+					{canCreate}
 					onItemClick={handleFileClick}
 					onSortChange={handleSortChange}
 					onSelectionChange={handleSelectionChange}
@@ -626,8 +709,33 @@
 	file={previewFile}
 	allFiles={previewableFiles}
 	onNavigate={handlePreviewNavigate}
+	onFileSaved={handleFileSaved}
 	onClose={handleClosePreview}
 />
+
+<!-- Create File/Folder Dialog -->
+<Modal
+	open={createDialog.open}
+	title={createDialog.type === 'file' ? 'New File' : 'New Folder'}
+	onclose={closeCreateDialog}
+>
+	<div class="flex flex-col gap-4">
+		<p class="text-sm text-text-secondary">
+			Enter a name for the new {createDialog.type === 'file' ? 'file' : 'folder'}:
+		</p>
+		<Input
+			bind:value={createDialog.name}
+			placeholder={createDialog.type === 'file' ? 'untitled.txt' : 'New Folder'}
+			onkeydown={(e) => e.key === 'Enter' && handleCreateConfirm()}
+		/>
+	</div>
+	{#snippet footer()}
+		<Button variant="secondary" onclick={closeCreateDialog}>Cancel</Button>
+		<Button variant="primary" onclick={handleCreateConfirm}>
+			Create {createDialog.type === 'file' ? 'File' : 'Folder'}
+		</Button>
+	{/snippet}
+</Modal>
 
 <!-- Rename Dialog -->
 <Modal

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,36 +1,110 @@
 <script lang="ts">
 	/**
-	 * Settings page - user preferences and account management
-	 * Design follows the same visual language as the file browser sidebar
+	 * Settings page - workspace-style preferences screen matching the file browser shell.
 	 */
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import { authStore } from '$lib/stores/auth';
 	import { settingsStore, type UserSettings } from '$lib/stores/settings';
+	import SearchBar from '$lib/components/SearchBar.svelte';
+	import { Button, Select, Toggle } from '$lib/components/ui';
 	import {
 		ChevronLeft,
 		Eye,
-		RotateCcw,
 		Layout,
-		MousePointer,
-		User,
 		LogOut,
+		MousePointer,
+		RotateCcw,
 		Save,
-		X,
+		Settings,
+		User,
+		X
 	} from 'lucide-svelte';
-	import { Button, Toggle, Select } from '$lib/components/ui';
-	import { SettingsSection, SettingsRow } from '$lib/components/settings';
+
+	type SettingsSectionId = 'display' | 'behavior' | 'defaults' | 'account';
+	type SettingsCategory = 'all' | SettingsSectionId;
 
 	let settings = $state<UserSettings>({ ...$settingsStore });
-	const hasChanges = $derived(JSON.stringify(settings) !== JSON.stringify($settingsStore));
+	let activeCategory = $state<SettingsCategory>('all');
+	let searchQuery = $state('');
 
-	// Section collapse state
-	let displayCollapsed = $state(false);
-	let behaviorCollapsed = $state(false);
-	let viewCollapsed = $state(false);
-	let accountCollapsed = $state(false);
+	const hasChanges = $derived(JSON.stringify(settings) !== JSON.stringify($settingsStore));
+	const normalizedSearch = $derived(searchQuery.trim().toLowerCase());
+
+	const navItems: Array<{
+		id: SettingsCategory;
+		label: string;
+		description: string;
+		icon: typeof Eye;
+	}> = [
+		{
+			id: 'all',
+			label: 'Show All',
+			description: 'Every setting in one view',
+			icon: Settings
+		},
+		{
+			id: 'display',
+			label: 'File Display',
+			description: 'Hidden files, extensions, density',
+			icon: Eye
+		},
+		{
+			id: 'behavior',
+			label: 'Behavior',
+			description: 'Delete and preview behavior',
+			icon: MousePointer
+		},
+		{
+			id: 'defaults',
+			label: 'Default View',
+			description: 'Sorting and layout choices',
+			icon: Layout
+		},
+		{
+			id: 'account',
+			label: 'Account',
+			description: 'Session and reset controls',
+			icon: User
+		}
+	];
+
+	const sortByOptions = [
+		{ value: 'name', label: 'Name' },
+		{ value: 'size', label: 'Size' },
+		{ value: 'modTime', label: 'Date modified' },
+		{ value: 'type', label: 'Type' }
+	];
+
+	const sortDirOptions = [
+		{ value: 'asc', label: 'Ascending' },
+		{ value: 'desc', label: 'Descending' }
+	];
+
+	const viewModeOptions = [
+		{ value: 'list', label: 'List' },
+		{ value: 'grid', label: 'Grid' }
+	];
+
+	const navButtonClass =
+		'group flex w-full cursor-pointer items-start gap-2.5 border-none bg-transparent px-3 py-2 text-left transition-colors duration-100 hover:bg-surface-secondary';
+	const activeNavClass = 'bg-selection text-white hover:bg-selection-hover';
+	const inactiveNavClass = 'text-text-secondary hover:text-text-primary';
+	const toolbarButtonClass =
+		'flex h-7 w-7 cursor-pointer items-center justify-center rounded border-none bg-transparent text-text-secondary transition-all duration-100 hover:bg-surface-elevated hover:text-text-primary';
+	const panelClass =
+		'scroll-mt-4 overflow-hidden rounded-lg border border-border-primary bg-surface-secondary shadow-[0_18px_70px_rgba(0,0,0,0.18)]';
+	const panelHeaderClass =
+		'flex items-start justify-between gap-4 border-b border-border-secondary bg-surface-primary/55 px-4 py-3';
+	const settingRowClass =
+		'flex items-center justify-between gap-4 border-b border-border-secondary px-4 py-3 last:border-b-0';
 
 	function handleSave() {
 		settingsStore.set(settings);
+	}
+
+	function handleCancel() {
+		settings = { ...$settingsStore };
 	}
 
 	function handleReset() {
@@ -38,196 +112,323 @@
 		settings = { ...$settingsStore };
 	}
 
-	function handleCancel() {
-		settings = { ...$settingsStore };
-	}
-
 	async function handleLogout() {
 		await authStore.logout();
-		goto('/login');
+		goto(resolve('/login'));
 	}
 
 	function goBack() {
-		goto('/browse');
+		goto(resolve('/browse'));
 	}
 
-	const sortByOptions = [
-		{ value: 'name', label: 'Name' },
-		{ value: 'size', label: 'Size' },
-		{ value: 'modTime', label: 'Date modified' },
-		{ value: 'type', label: 'Type' },
-	];
+	function handleSearchInput(query: string) {
+		searchQuery = query;
+	}
 
-	const sortDirOptions = [
-		{ value: 'asc', label: 'Ascending' },
-		{ value: 'desc', label: 'Descending' },
-	];
+	function handleSearchClear() {
+		searchQuery = '';
+	}
 
-	const viewModeOptions = [
-		{ value: 'list', label: 'List' },
-		{ value: 'grid', label: 'Grid' },
-	];
+	function matchesSearch(...values: string[]): boolean {
+		if (!normalizedSearch) return true;
+		return values.some((value) => value.toLowerCase().includes(normalizedSearch));
+	}
 
-	// Shared styles for navigation items
-	const navItemClass = 'w-full flex items-center gap-2.5 py-1.5 px-3 pl-5 bg-transparent border-none text-[13px] cursor-pointer text-left transition-colors duration-100 hover:bg-surface-secondary';
-	const backButtonClass = 'w-7 h-7 flex items-center justify-center bg-transparent border-none rounded text-text-secondary cursor-pointer transition-all duration-100 hover:bg-surface-elevated hover:text-text-primary';
+	function categoryAllows(section: SettingsSectionId): boolean {
+		return activeCategory === 'all' || activeCategory === section;
+	}
+
+	const showDisplaySection = $derived(
+		categoryAllows('display') &&
+			matchesSearch(
+				'file display',
+				'hidden files',
+				'file extensions',
+				'compact mode',
+				'density',
+				'lists',
+				'grids'
+			)
+	);
+	const showBehaviorSection = $derived(
+		categoryAllows('behavior') &&
+			matchesSearch(
+				'behavior',
+				'confirm before delete',
+				'delete',
+				'preview on single click',
+				'preview'
+			)
+	);
+	const showDefaultsSection = $derived(
+		categoryAllows('defaults') &&
+			matchesSearch('default view', 'sort by', 'sort direction', 'view mode', 'list', 'grid')
+	);
+	const showAccountSection = $derived(
+		categoryAllows('account') &&
+			matchesSearch('account', 'session', 'reset defaults', 'logout', 'local preferences')
+	);
+	const hasSearchResults = $derived(
+		showDisplaySection || showBehaviorSection || showDefaultsSection || showAccountSection
+	);
 </script>
 
 <svelte:head>
 	<title>Settings - File Manager</title>
 </svelte:head>
 
-<div class="flex h-screen w-full bg-surface-primary overflow-hidden">
-	<!-- Settings Sidebar (matching main sidebar width) -->
-	<aside class="w-[220px] min-w-[220px] bg-surface-primary border-r border-border-secondary flex flex-col overflow-y-auto overflow-x-hidden">
-		<!-- Header -->
-		<div class="flex items-center gap-2 px-3 py-3 border-b border-border-secondary">
-			<button
-				type="button"
-				class={backButtonClass}
-				onclick={goBack}
-				title="Back to Files"
-			>
-				<ChevronLeft size={18} />
-			</button>
-			<span class="text-text-primary text-[13px] font-medium">Settings</span>
+<div class="flex h-screen w-full overflow-hidden bg-surface-primary text-text-primary">
+	<aside
+		class="flex w-[220px] min-w-[220px] flex-col overflow-x-hidden overflow-y-auto border-r border-border-secondary bg-surface-primary"
+	>
+		<div class="border-b border-border-secondary px-3 py-3">
+			<div class="flex items-center gap-2 text-[13px] font-medium text-text-primary">
+				<Settings size={16} class="text-accent" />
+				<span>Settings</span>
+			</div>
 		</div>
 
-		<!-- Navigation within settings -->
-		<nav class="flex-1 py-2">
-			<button
-				type="button"
-				class="{navItemClass} text-text-primary bg-selection"
-			>
-				<Eye size={16} class="shrink-0 opacity-80" />
-				<span>Preferences</span>
-			</button>
-			<button
-				type="button"
-				class="{navItemClass} text-text-secondary"
-				onclick={handleLogout}
-			>
-				<LogOut size={16} class="shrink-0 opacity-80" />
-				<span>Logout</span>
-			</button>
+		<nav class="flex-1 py-2" aria-label="Settings sections">
+			{#each navItems as item (item.id)}
+				<button
+					type="button"
+					class="{navButtonClass} {activeCategory === item.id ? activeNavClass : inactiveNavClass}"
+					onclick={() => (activeCategory = item.id)}
+					aria-current={activeCategory === item.id ? 'page' : undefined}
+				>
+					<item.icon size={16} class="mt-0.5 shrink-0 opacity-80" />
+					<span class="min-w-0">
+						<span class="block text-[13px] leading-5">{item.label}</span>
+						<span
+							class="block overflow-hidden text-[11px] leading-4 text-ellipsis whitespace-nowrap {activeCategory ===
+							item.id
+								? 'text-white/70'
+								: 'text-text-muted'}"
+						>
+							{item.description}
+						</span>
+					</span>
+				</button>
+			{/each}
 		</nav>
 	</aside>
 
-	<!-- Main content area -->
-	<div class="flex-1 flex flex-col min-w-0">
-		<!-- Toolbar matching browse toolbar -->
-		<div class="flex items-center gap-2 px-3 py-1.5 bg-surface-primary border-b border-border-secondary">
-			<div class="flex items-center gap-2">
-				<button
-					type="button"
-					class={backButtonClass}
-					onclick={goBack}
-					title="Back"
+	<div class="flex min-w-0 flex-1 flex-col">
+		<div
+			class="flex items-center gap-2 border-b border-border-secondary bg-surface-primary px-3 py-1.5"
+		>
+			<button type="button" class={toolbarButtonClass} onclick={goBack} title="Back to files">
+				<ChevronLeft size={18} />
+			</button>
+
+			<div
+				class="flex min-w-0 flex-1 items-center gap-1.5 rounded border border-border-primary bg-surface-secondary px-2 py-1"
+			>
+				<span class="text-[13px] whitespace-nowrap text-text-secondary">Settings</span>
+				<span class="text-xs text-text-muted">/</span>
+				<span class="text-[13px] whitespace-nowrap text-text-primary">Preferences</span>
+			</div>
+
+			<div class="w-64 shrink-0 lg:w-96">
+				<SearchBar
+					value={searchQuery}
+					onInput={handleSearchInput}
+					onClear={handleSearchClear}
+					placeholder="Search settings..."
+					compact
+				/>
+			</div>
+
+			<div class="flex gap-1">
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={handleCancel}
+					title="Discard changes"
+					disabled={!hasChanges}
 				>
-					<ChevronLeft size={18} />
-				</button>
+					<X size={16} />
+					<span class="hidden sm:inline">Cancel</span>
+				</Button>
+				<Button
+					variant="primary"
+					size="sm"
+					onclick={handleSave}
+					title="Save changes"
+					disabled={!hasChanges}
+				>
+					<Save size={16} />
+					<span class="hidden sm:inline">Save</span>
+				</Button>
 			</div>
-
-			<!-- Path bar style breadcrumb -->
-			<div class="flex-1 flex items-center gap-1.5 bg-surface-secondary border border-border-primary rounded px-2 py-1 min-w-0">
-				<span class="text-text-secondary text-[13px]">Settings</span>
-				<span class="text-text-muted text-xs">/</span>
-				<span class="text-text-primary text-[13px]">Preferences</span>
-			</div>
-
-			<!-- Action buttons -->
-			{#if hasChanges}
-				<div class="flex gap-1">
-					<Button variant="ghost" size="sm" onclick={handleCancel} title="Discard changes">
-						<X size={16} />
-						<span class="hidden sm:inline">Cancel</span>
-					</Button>
-					<Button variant="primary" size="sm" onclick={handleSave} title="Save changes">
-						<Save size={16} />
-						<span class="hidden sm:inline">Save</span>
-					</Button>
-				</div>
-			{/if}
 		</div>
 
-		<!-- Settings content (styled like file list area) -->
-		<div class="flex-1 overflow-auto">
-			<div class="max-w-[600px]">
-				<!-- File Display Section -->
-				<SettingsSection title="File Display" icon={Eye} bind:collapsed={displayCollapsed}>
-					<SettingsRow label="Show hidden files" description="Display files starting with a dot">
-						<Toggle bind:checked={settings.showHiddenFiles} />
-					</SettingsRow>
-
-					<SettingsRow label="Show file extensions" description="Display extensions in file list">
-						<Toggle bind:checked={settings.showFileExtensions} />
-					</SettingsRow>
-
-					<SettingsRow label="Compact mode" description="Reduce spacing for more items">
-						<Toggle bind:checked={settings.compactMode} />
-					</SettingsRow>
-				</SettingsSection>
-
-				<!-- Behavior Section -->
-				<SettingsSection title="Behavior" icon={MousePointer} bind:collapsed={behaviorCollapsed}>
-					<SettingsRow label="Confirm before delete" description="Show confirmation dialog">
-						<Toggle bind:checked={settings.confirmDelete} />
-					</SettingsRow>
-
-					<SettingsRow label="Preview on single click" description="Open preview with single click">
-						<Toggle bind:checked={settings.previewOnSingleClick} />
-					</SettingsRow>
-				</SettingsSection>
-
-				<!-- Default View Section -->
-				<SettingsSection title="Default View" icon={Layout} bind:collapsed={viewCollapsed}>
-					<SettingsRow label="Sort by" description="Default sort field">
-						<div class="w-32">
-							<Select options={sortByOptions} bind:value={settings.defaultSortBy} />
-						</div>
-					</SettingsRow>
-
-					<SettingsRow label="Sort direction" description="Ascending or descending">
-						<div class="w-32">
-							<Select options={sortDirOptions} bind:value={settings.defaultSortDir} />
-						</div>
-					</SettingsRow>
-
-					<SettingsRow label="View mode" description="List or grid view">
-						<div class="w-32">
-							<Select options={viewModeOptions} bind:value={settings.defaultViewMode} />
-						</div>
-					</SettingsRow>
-				</SettingsSection>
-
-				<!-- Account Section -->
-				<SettingsSection title="Account" icon={User} bind:collapsed={accountCollapsed}>
-					<div class="px-3">
-						<div class="flex gap-2 pt-2">
-							<Button variant="secondary" size="sm" onclick={handleReset}>
-								<RotateCcw size={14} />
-								Reset to Defaults
-							</Button>
-							<Button variant="danger" size="sm" onclick={handleLogout}>
-								<LogOut size={14} />
-								Logout
-							</Button>
-						</div>
+		<main class="relative flex-1 overflow-auto">
+			<div class="relative mx-auto flex max-w-[980px] flex-col gap-4 px-6 py-6">
+				{#if !hasSearchResults}
+					<div
+						class="rounded-lg border border-border-primary bg-surface-secondary px-4 py-8 text-center"
+					>
+						<div class="text-sm text-text-primary">No settings found</div>
+						<div class="mt-1 text-xs text-text-muted">Try a different search term.</div>
 					</div>
-				</SettingsSection>
-			</div>
-		</div>
-
-		<!-- Status bar matching browse status bar -->
-		<div class="flex items-center justify-between px-3 py-1.5 bg-surface-primary border-t border-border-secondary text-[11px] text-text-muted">
-			<span>
-				{#if hasChanges}
-					<span class="text-warning">● Unsaved changes</span>
-				{:else}
-					All changes saved
 				{/if}
-			</span>
-			<span>Preferences</span>
-		</div>
+
+				{#if showDisplaySection}
+					<section id="display" class={panelClass}>
+						<div class={panelHeaderClass}>
+							<div>
+								<h2 class="m-0 flex items-center gap-2 text-sm font-medium">
+									<Eye size={16} class="text-accent" />
+									File Display
+								</h2>
+							</div>
+						</div>
+
+						<div>
+							{#if matchesSearch('show hidden files', 'display files and folders that start with a dot')}
+								<div class={settingRowClass}>
+									<div>
+										<div class="text-[13px] text-text-primary">Show hidden files</div>
+									</div>
+									<Toggle bind:checked={settings.showHiddenFiles} label="Show hidden files" />
+								</div>
+							{/if}
+
+							{#if matchesSearch('show file extensions', 'keep extensions visible in file names')}
+								<div class={settingRowClass}>
+									<div>
+										<div class="text-[13px] text-text-primary">Show file extensions</div>
+									</div>
+									<Toggle bind:checked={settings.showFileExtensions} label="Show file extensions" />
+								</div>
+							{/if}
+
+							{#if matchesSearch('compact mode', 'reduce row and tile spacing', 'density')}
+								<div class={settingRowClass}>
+									<div>
+										<div class="text-[13px] text-text-primary">Compact mode</div>
+									</div>
+									<Toggle bind:checked={settings.compactMode} label="Compact mode" />
+								</div>
+							{/if}
+						</div>
+					</section>
+				{/if}
+
+				{#if showBehaviorSection}
+					<section id="behavior" class={panelClass}>
+						<div class={panelHeaderClass}>
+							<div>
+								<h2 class="m-0 flex items-center gap-2 text-sm font-medium">
+									<MousePointer size={16} class="text-accent" />
+									Behavior
+								</h2>
+							</div>
+						</div>
+
+						<div>
+							{#if matchesSearch('confirm before delete', 'confirmation', 'delete')}
+								<div class={settingRowClass}>
+									<div>
+										<div class="text-[13px] text-text-primary">Confirm before delete</div>
+									</div>
+									<Toggle bind:checked={settings.confirmDelete} label="Confirm before delete" />
+								</div>
+							{/if}
+
+							{#if matchesSearch('preview on single click', 'preview', 'single click')}
+								<div class={settingRowClass}>
+									<div>
+										<div class="text-[13px] text-text-primary">Preview on single click</div>
+									</div>
+									<Toggle
+										bind:checked={settings.previewOnSingleClick}
+										label="Preview on single click"
+									/>
+								</div>
+							{/if}
+						</div>
+					</section>
+				{/if}
+
+				{#if showDefaultsSection}
+					<section id="defaults" class={panelClass}>
+						<div class={panelHeaderClass}>
+							<div>
+								<h2 class="m-0 flex items-center gap-2 text-sm font-medium">
+									<Layout size={16} class="text-accent" />
+									Default Directory View
+								</h2>
+							</div>
+						</div>
+
+						<div>
+							{#if matchesSearch('sort by', 'default sort field', 'name', 'size', 'date modified', 'type')}
+								<div class={settingRowClass}>
+									<div>
+										<div class="text-[13px] text-text-primary">Sort by</div>
+									</div>
+									<div class="w-44">
+										<Select options={sortByOptions} bind:value={settings.defaultSortBy} />
+									</div>
+								</div>
+							{/if}
+
+							{#if matchesSearch('sort direction', 'ascending', 'descending')}
+								<div class={settingRowClass}>
+									<div>
+										<div class="text-[13px] text-text-primary">Sort direction</div>
+									</div>
+									<div class="w-44">
+										<Select options={sortDirOptions} bind:value={settings.defaultSortDir} />
+									</div>
+								</div>
+							{/if}
+
+							{#if matchesSearch('view mode', 'list', 'grid')}
+								<div class={settingRowClass}>
+									<div>
+										<div class="text-[13px] text-text-primary">View mode</div>
+									</div>
+									<div class="w-44">
+										<Select options={viewModeOptions} bind:value={settings.defaultViewMode} />
+									</div>
+								</div>
+							{/if}
+						</div>
+					</section>
+				{/if}
+
+				{#if showAccountSection}
+					<section id="account" class={panelClass}>
+						<div class={panelHeaderClass}>
+							<div>
+								<h2 class="m-0 flex items-center gap-2 text-sm font-medium">
+									<User size={16} class="text-accent" />
+									Account
+								</h2>
+							</div>
+						</div>
+
+						<div class="grid gap-4 p-4 md:grid-cols-[1fr_auto] md:items-center">
+							<div>
+								<div class="text-[13px] text-text-primary">Signed in session</div>
+							</div>
+							<div class="flex flex-wrap gap-2">
+								<Button variant="secondary" size="sm" onclick={handleReset}>
+									<RotateCcw size={14} />
+									Reset Defaults
+								</Button>
+								<Button variant="danger" size="sm" onclick={handleLogout}>
+									<LogOut size={14} />
+									Logout
+								</Button>
+							</div>
+						</div>
+					</section>
+				{/if}
+			</div>
+		</main>
 	</div>
 </div>

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "website",
   "type": "module",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Summary
- Add create-file and create-folder support through the file API and right-click menu.
- Make Monaco text/code previews editable with explicit save support.
- Redesign the settings page to match the file-browser workspace, with settings search, category filtering, stable save/cancel actions, and a single logout path.
- Add awesome-selfhosted metadata and bump app metadata to v0.1.4.

## Validation
- `go test ./...` in `backend`
- `bun run check` in `frontend` (passes with existing InlineRename warning)
- `bun run build` in `frontend`

Closes #7
Closes #8
